### PR TITLE
Install redcarpet and require rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ You can download different formats from [rendered](https://github.com/coderoshi/
 ### Building
 
 ```
-gem install bundler
+[sudo] gem install bundler
 bundle install
+[sudo] gem install redcarpet
 ```
 
 All text is in markdown. To build the book, you must install [calibre](http://manual.calibre-ebook.com/cli/cli-index.html).

--- a/bookgen.rb
+++ b/bookgen.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require "rubygems"
 require 'redcarpet'
 
 OUTPUT_DIR = 'rendered'


### PR DESCRIPTION
At least in OSX 10.8, it's necessary to install redcarpet and also to require rubygems to find the redcarpet gem.
