### PR TITLE
App guide: better integration, drop much incomplete content

### DIFF
--- a/en/05-app-guide.md
+++ b/en/05-app-guide.md
@@ -644,7 +644,7 @@ to define applications which enforce ACID semantics.
 
 ### Further reading
 
-* [HAT, not CAP: Introducing Highly Available Transactions](http://www.bailis.org/blog/hat-not-cap-introducing-highly-available-transactions/) (Peter Bailis's blog)
+* [Scalable Atomic Visibility with RAMP Transactions](http://www.bailis.org/blog/scalable-atomic-visibility-with-ramp-transactions/) (Peter Bailis's blog)
 
 
 


### PR DESCRIPTION
Quite a bit of cleanup.

Things that could still use work before print edition, time permitting:
- Make Markdown in chapter 5 look more like HTML (ugh) as in other chapters
- More cross-references between Eric's content and mine
- Take a look at the tuning content in chapters 3 and 5 and make sure the same messages are being conveyed in each (and consider whether they should be merged)
